### PR TITLE
feat: add `configure_modes` option for different notification presets

### DIFF
--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -7,9 +7,9 @@
     </properties>
 
     <strings>
-       <string id="time_title">Countdown Timer(min)</string>
-       <string id="alarms_title">Alarms</string>
-    <string id="mode_title">Mode</string>
+        <string id="time_title">Countdown Timer(min)</string>
+        <string id="alarms_title">Alarms</string>
+        <string id="mode_title">Mode</string>
     </strings>
 
     <settings>

--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -3,11 +3,13 @@
     <properties>
         <property id="time" type="number">5</property>
         <property id="alarms" type="boolean">true</property>
+        <property id="mode" type="number">0</property>
     </properties>
 
     <strings>
        <string id="time_title">Countdown Timer(min)</string>
        <string id="alarms_title">Alarms</string>
+    <string id="mode_title">Mode</string>
     </strings>
 
     <settings>
@@ -17,6 +19,9 @@
 
         <setting propertyKey="@Properties.alarms" title="@Strings.alarms_title">
             <settingConfig type="boolean" />
+        </setting>
+        <setting propertyKey="@Properties.mode" title="@Strings.mode_title">
+            <settingConfig type="numeric" />
         </setting>
     </settings>
 </resources>

--- a/resources/resources.xml
+++ b/resources/resources.xml
@@ -4,6 +4,11 @@
         <menu-item id="start_timer" label="Start timer"></menu-item>
         <menu-item id="set_timer" label="Set timer"></menu-item>
         <menu-item id="set_alarms" label="Toggle alarms"></menu-item>
+        <menu-item id="set_mode" label="Configure Mode"></menu-item>"
+    </menu>
+    <menu id="ModeMenu" title="Mode">
+        <menu-item id="mode_standard" label="Standard"></menu-item>
+        <menu-item id="mode_dynamic" label="Dynamic"></menu-item>
     </menu>
     <menu id="StopMenu" title="Exit">
         <menu-item id="save_btn" label="Save"></menu-item>

--- a/source/CountDown.mc
+++ b/source/CountDown.mc
@@ -21,6 +21,11 @@ class CountDown {
     var finalRingTime = 5000;
     var raceStartTime = null;
 
+    enum {
+        BUZZ_SHORT,
+        BUZZ_LONG
+    }
+
     function initialize(sailingapp) {
         Sys.println("countdown: initialize");
         app = sailingapp.weak();
@@ -56,28 +61,76 @@ class CountDown {
         timerRunning = true;
     }
 
+    function finishCountdown() {
+        app.get().addLap();
+        raceStartTime = Time.now();
+        endTimer();
+        timerComplete = true;
+        finalRing();
+        timerEnd = new Timer.Timer();
+        timerEnd.start(method(:finalRing), 500, true );
+    }
+
     function timerCallback() as Void {
-        if (secLeft > 1) {
-            if (secLeft < 11) {
-                ring();
-            }
-            if ((secLeft-1) % 30 == 0) {
-                ring();
-                if ((secLeft-1) % 60 == 0) {
-                    ring();
+        var current_mode = app.get().getMode();
+        Sys.println("Current Mode: " + current_mode);
+        if (current_mode == MODE_TYPE_STANDARD){
+            if (secLeft > 1) {
+                if (secLeft < 11) {
+                    ring(BUZZ_SHORT, 1, true);
                 }
+                if ((secLeft-1) % 30 == 0) {
+                    ring(BUZZ_SHORT, 1, true);
+                    if ((secLeft-1) % 60 == 0) {
+                        ring(BUZZ_SHORT, 1, true);
+                    }
+                }
+                updateTimer();
+            } else {
+                finishCountdown();
             }
-            updateTimer();
-        } else {
-            app.get().addLap();
-            raceStartTime = Time.now();
-            endTimer();
-            timerComplete = true;
-            finalRing();
-            timerEnd = new Timer.Timer();
-            timerEnd.start(method(:finalRing), 500, true );
+        } else if (current_mode == MODE_TYPE_DYNAMIC) {
+            var minutes = ((secLeft - 1) / 60).toNumber();
+            var tens_seconds = ((secLeft - 1) / 10).toNumber();
+            if (secLeft > 1) {
+                // Buzz the same number of minutes left
+                if (((secLeft -1) % 60 == 0) && (secLeft > 60)) {
+                    ring(BUZZ_SHORT, minutes, true);
+                }
+                // Buzz once on the 30 seconds
+                else if (((secLeft - 1) % 30 == 0) && (secLeft > 60)) {
+                    ring(BUZZ_SHORT, 1, true);
+                }
+                // Buzz the number of secconds
+                else if (((secLeft - 1) % 10 == 0) && (secLeft <= 60) && (secLeft > 11)) {
+                    if(tens_seconds > 4){
+                        // Hack because arrays max size 8
+                        ring(BUZZ_SHORT, 4, true);
+                        ring(BUZZ_SHORT, 1, true);
+                    }
+                    else{
+                        ring(BUZZ_SHORT, tens_seconds, true);
+                    }
+                }
+                // from 15 to 10 seconds, single short buzz
+                else if (((secLeft - 1) > 10) && ((secLeft - 1) < 16)) {
+                    ring(BUZZ_SHORT, 1, true);
+                }
+                // from 10 to 6 seconds, double short buzz
+                else if (((secLeft - 1) > 5) && ((secLeft - 1) < 11)) {
+                    ring(BUZZ_SHORT, 2, true);
+                }
+                // from 5 to 1 seconds, triple short buzz
+                else if (((secLeft - 1) > 0) && ((secLeft - 1) < 6)) {
+                    ring(BUZZ_SHORT, 3, true);
+                }
+                updateTimer();
+            } else {
+                finishCountdown();
+            }
         }
-            WatchUi.requestUpdate();
+
+        WatchUi.requestUpdate();
     }
 
     function updateTimer() {
@@ -91,6 +144,7 @@ class CountDown {
         }
         secLeft = ((secLeft / 60) + 1) * 60;
         Sys.println("fixTimeUp: " + (secLeft / 60 + 1));
+        ring(BUZZ_SHORT, 1, false);
         Ui.requestUpdate();
     }
 
@@ -100,6 +154,7 @@ class CountDown {
         }
         secLeft = (secLeft / 60) * 60;
         Sys.println("fixTimeDown: " + secLeft / 60);
+        ring(BUZZ_SHORT, 1, false);
         Ui.requestUpdate();
     }
 
@@ -109,20 +164,41 @@ class CountDown {
         Ui.requestUpdate();
     }
 
-    function ring() {
+    function ring(buzz_type, times, tone) {
         if (app.get().getAlarms() == false) {
             return;
         }
-        Sys.println("ring: " + secLeft);
-        if (Attention has :ToneProfile) {
-            Attention.playTone(Attention.TONE_ALARM);
-        }
-        if (Attention has :vibrate) {
-            var vibeData =
-            [
-                new Attention.VibeProfile(50, 500) // On for two seconds
-            ];
-            Attention.vibrate(vibeData);
+        Sys.println("ring: " + times);
+        if (buzz_type == BUZZ_SHORT) {
+            if (times > 5){
+                Sys.println("ring: called with too many iterations (max 4)");
+                return;
+            }
+            var vibeData = new [times * 2];
+            var toneData = new [times * 2];
+            for (var i = 0; i < (times * 2); i++) {
+                if (i % 2 == 0) {
+                    vibeData[i] = new Attention.VibeProfile(80, 200);
+                    toneData[i] = new Attention.ToneProfile(2500, 200);
+                } else {
+                    vibeData[i] = new Attention.VibeProfile(0, 50);
+                    toneData[i] = new Attention.ToneProfile(0, 50);
+                }
+            }
+            if (Attention has :ToneProfile && tone == true) {
+                Attention.playTone({:toneProfile=>toneData});
+            }
+            if (Attention has :vibrate) {
+                Attention.vibrate(vibeData);
+            }
+        } else if(buzz_type == BUZZ_LONG){
+            if (Attention has :ToneProfile && tone == true) {
+                Attention.playTone({:toneProfile=>[new Attention.ToneProfile(2500, 500)]});
+            }
+            if (Attention has :vibrate) {
+                var vibe_data = [new Attention.VibeProfile(50, 3000)];
+                Attention.vibrate(vibe_data);
+            }
         }
     }
 
@@ -132,7 +208,7 @@ class CountDown {
         }
         if (finalRingTime > 0) {
             finalRingTime -= 500;
-            ring();
+            ring(BUZZ_LONG, 1, true);
         } else {
             finalRingTime = 5000;
             timerComplete = false;

--- a/source/CountDown.mc
+++ b/source/CountDown.mc
@@ -101,7 +101,7 @@ class CountDown {
                 else if (((secLeft - 1) % 30 == 0) && (secLeft > 60)) {
                     ring(BUZZ_SHORT, 1, true);
                 }
-                // Buzz the number of secconds
+                // Buzz the number of seconds
                 else if (((secLeft - 1) % 10 == 0) && (secLeft <= 60) && (secLeft > 11)) {
                     if(tens_seconds > 4){
                         // Hack because arrays max size 8

--- a/source/ModeMenuDelegate.mc
+++ b/source/ModeMenuDelegate.mc
@@ -1,0 +1,23 @@
+using Toybox.WatchUi as Ui;
+using Toybox.Application as App;
+using Toybox.System as Sys;
+
+class ModeMenuDelegate extends Ui.MenuInputDelegate {
+
+    function initialize() {
+        // Call the setMode function with the desired enum value
+        MenuInputDelegate.initialize();
+    }
+
+    function onMenuItem(item) {
+        Sys.println("onMenuItem: " + item);
+        if (item == :mode_standard) {'
+            Sys.println("selected standard mode");
+            App.getApp().setMode(MODE_TYPE_STANDARD);
+        } else if (item == :mode_dynamic) {
+            Sys.println("selected dynamic mode");
+            App.getApp().setMode(MODE_TYPE_DYNAMIC);
+        }
+    }
+
+}

--- a/source/SailingApp.mc
+++ b/source/SailingApp.mc
@@ -9,6 +9,10 @@ using Toybox.ActivityRecording;
 using Toybox.Position as Position;
 using Toybox.System as Sys;
 
+enum {
+    MODE_TYPE_STANDARD,
+    MODE_TYPE_DYNAMIC
+}
 
 class SailingApp extends App.AppBase {
 
@@ -50,6 +54,23 @@ class SailingApp extends App.AppBase {
         }
         Sys.println("app : setAlarms " + alarms);
         Properties.setValue("alarms", alarms);
+    }
+
+    function getMode() {
+        if (! (App has :Properties)) {
+            Sys.println("app : getMode no properties");
+            return true;
+        }
+        return Properties.getValue("mode");
+    }
+
+    function setMode(mode) {
+        if (! (App has :Properties)) {
+            Sys.println("app : setMode no properties");
+            return;
+        }
+        Sys.println("app : setMode " + mode);
+        Properties.setValue("mode", mode);
     }
 
     function initialize() {

--- a/source/SailingMenuDelegate.mc
+++ b/source/SailingMenuDelegate.mc
@@ -17,6 +17,9 @@ class SailingMenuDelegate extends Ui.MenuInputDelegate {
         } else if (item == :set_alarms) {
             Sys.println("set alarms pressed");
             App.getApp().setAlarms(! App.getApp().getAlarms());
+        } else if (item == :set_mode) {
+            Sys.println("set mode pressed");
+            Ui.pushView(new Rez.Menus.ModeMenu(), new ModeMenuDelegate(), Ui.SLIDE_LEFT);
         }
     }
 

--- a/source/SailingView.mc
+++ b/source/SailingView.mc
@@ -137,7 +137,7 @@ class SailingView extends Ui.View {
                         dc.drawText((3 * (screenWidth / 4)) + unitsOffset, (screenHeight / 2), Gfx.FONT_MEDIUM, SPEED_UNIT, Gfx.TEXT_JUSTIFY_LEFT);
                         dc.drawText((subscreen.x + (subscreen.width / 2) + 4), (subscreen.y + (subscreen.height/4)), Gfx.FONT_MEDIUM, headingOnlyStr, Gfx.TEXT_JUSTIFY_CENTER);
                     }
-                } else {    
+                } else {
                     dc.drawText((screenWidth / 2), 0, Gfx.FONT_TINY , nowString, Gfx.TEXT_JUSTIFY_CENTER);
                     dc.drawText((screenWidth / 2), Gfx.getFontAscent(Gfx.FONT_MEDIUM), Gfx.FONT_NUMBER_THAI_HOT, speedStr, Gfx.TEXT_JUSTIFY_CENTER);
                     dc.drawText((screenWidth / 2), Gfx.getFontAscent(Gfx.FONT_NUMBER_THAI_HOT) + Gfx.getFontAscent(Gfx.FONT_MEDIUM) + 40, Gfx.FONT_MEDIUM, headingStr, Gfx.TEXT_JUSTIFY_CENTER);


### PR DESCRIPTION
## Background
There is a standard beep / vibration preset for a countdown. This PR adds the notion of 'modes' that allow us to create preset notification structures. The structure of interest is a classic 'Ronstan' style sound / notification system which sailors know well. The addition of `modes` ensures that the existing functionality remains.

![fenix7-configure-modes](https://github.com/user-attachments/assets/d0d0dcdd-fcc7-410e-bb15-714474102313)


## How it works
1. Go to the menu, then scroll down and select `Configure Mode`
2. In this menu you can select `Standard` which uses the existing methods, and `Dynamic` which is a slight variation of a classic `Ronstan` start sequence.

## Known Limitations / Nuance
- No persistence between app starts
- Doesn't exit menu after selection
- The word `Dynamic` might be misleading, it's not quite Ronstan but probably more informative.

## Possible Future Work
- Adding additional functionality coupled to each mode
- Addition additional presets (for different start watches)
- Customisable notification slots (ideal but also a stretch)
- Persistence between app starts

*Note that I'm not a MonkeyC dev and I don't fully understand some of the limitations and mechanisms so please recommend any changes.

## Testing
I've been using this change for a couple of months and haven't seen any issues with it so far.