### PR TITLE
Add Cruise sailing mode to disable race countdown.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,15 +3,16 @@
 Available on [GARMIN app store](https://apps.garmin.com/en-US/apps/db7493a2-fb16-4d34-a36b-1aa6af6b87b5)
 
 Sailing is a watch app to display speed in knots and heading direction, as well as record the tracking.
-There is a configurable race countdown and a race timing starts at the end of this countdown.
+It supports a simple Cruise mode for non-racing sailing, and an optional Race mode with a configurable countdown.
 
 ## Features
+- Cruise / Race sailing mode (Race is the default)
 - configurable race start countdown sequence (by default 5 minutes)
 - pre-start GPS tracking
 - race GPS tracking (new lap)
 - current speed (in knots)
 - current direction (heading in degrees)
-- time since start
+- time since start (Race mode, after countdown)
 - enable/disable alarms (still necessary to have the "In App" watch parameters set for bips and vibration during the countdown)
 
 ![Main View](https://services.garmin.com/appsLibraryBusinessServices_v0/rest/apps/db7493a2-fb16-4d34-a36b-1aa6af6b87b5/screenshots/257fd487-7913-4018-b8f9-c900952358b9)
@@ -19,7 +20,9 @@ There is a configurable race countdown and a race timing starts at the end of th
 ![Timer View](https://services.garmin.com/appsLibraryBusinessServices_v0/rest/apps/db7493a2-fb16-4d34-a36b-1aa6af6b87b5/screenshots/88e938da-6c93-46c1-824f-9fa40839c84b)
 
 ## How to use it
-- press the select (start/stop) to start or cancel the race start countdown and alternatively via the menu
-- the activity tracking will wait for GPS signal and start automatically until you exit the app
-- A new track element is created everytime the pre-start timer reaches 0
-- if you missed the initial signal, you can adjust to the lower/upper minute by pressing the "next page" or "previous page" button
+- open the menu and choose **Sailing mode** → **Cruise** or **Race**
+- in **Cruise** mode the Start button does not start a countdown; the app shows speed and bearing while GPS tracking records automatically
+- in **Race** mode, press the select (start/stop) button to start or cancel the race start countdown (also available via the menu)
+- the activity tracking waits for GPS signal and starts automatically until you exit the app
+- a new track lap is created every time the race countdown reaches 0
+- if you missed the initial signal, you can adjust to the lower/upper minute by pressing the "next page" or "previous page" button (Race mode only)

--- a/resources/properties.xml
+++ b/resources/properties.xml
@@ -4,12 +4,14 @@
         <property id="time" type="number">5</property>
         <property id="alarms" type="boolean">true</property>
         <property id="mode" type="number">0</property>
+        <property id="sailingMode" type="number">0</property>
     </properties>
 
     <strings>
         <string id="time_title">Countdown Timer(min)</string>
         <string id="alarms_title">Alarms</string>
-        <string id="mode_title">Mode</string>
+        <string id="mode_title">Countdown signals</string>
+        <string id="sailing_mode_title">Sailing mode</string>
     </strings>
 
     <settings>
@@ -21,6 +23,9 @@
             <settingConfig type="boolean" />
         </setting>
         <setting propertyKey="@Properties.mode" title="@Strings.mode_title">
+            <settingConfig type="numeric" />
+        </setting>
+        <setting propertyKey="@Properties.sailingMode" title="@Strings.sailing_mode_title">
             <settingConfig type="numeric" />
         </setting>
     </settings>

--- a/resources/resources.xml
+++ b/resources/resources.xml
@@ -4,9 +4,14 @@
         <menu-item id="start_timer" label="Start timer"></menu-item>
         <menu-item id="set_timer" label="Set timer"></menu-item>
         <menu-item id="set_alarms" label="Toggle alarms"></menu-item>
-        <menu-item id="set_mode" label="Configure Mode"></menu-item>"
+        <menu-item id="set_sailing_mode" label="Sailing mode"></menu-item>
+        <menu-item id="set_mode" label="Countdown signals"></menu-item>
     </menu>
-    <menu id="ModeMenu" title="Mode">
+    <menu id="SailingModeMenu" title="Sailing mode">
+        <menu-item id="sailing_mode_cruise" label="Cruise"></menu-item>
+        <menu-item id="sailing_mode_race" label="Race"></menu-item>
+    </menu>
+    <menu id="ModeMenu" title="Countdown signals">
         <menu-item id="mode_standard" label="Standard"></menu-item>
         <menu-item id="mode_dynamic" label="Dynamic"></menu-item>
     </menu>

--- a/source/CountDown.mc
+++ b/source/CountDown.mc
@@ -3,14 +3,15 @@ using Toybox.Timer;
 using Toybox.Attention as Attention;
 using Toybox.WatchUi as Ui;
 using Toybox.Lang;
+using Toybox.Time as Time;
 
 class CountDown {
 
     var app = null;
 
     // Timers
-    var myTimer;
-    var timerEnd;
+    var myTimer = null;
+    var timerEnd = null;
 
     // Status
     var timerComplete = false;
@@ -51,7 +52,11 @@ class CountDown {
         if (timerRunning == true) {
             return;
         }
-        secLeft = app.get().getDefaultTimerCount() * 60;
+        var sailingApp = app.get();
+        if (sailingApp == null) {
+            return;
+        }
+        secLeft = sailingApp.getDefaultTimerCount() * 60;
 
         updateTimer();
 
@@ -62,9 +67,13 @@ class CountDown {
     }
 
     function finishCountdown() {
-        app.get().addLap();
+        var sailingApp = app.get();
+        if (sailingApp != null) {
+            sailingApp.addLap();
+        }
         raceStartTime = Time.now();
-        endTimer();
+        stopMainTimer();
+        timerRunning = false;
         timerComplete = true;
         finalRing();
         timerEnd = new Timer.Timer();
@@ -72,7 +81,13 @@ class CountDown {
     }
 
     function timerCallback() as Void {
-        var current_mode = app.get().getMode();
+        var sailingApp = app.get();
+        if (sailingApp == null) {
+            stopMainTimer();
+            timerRunning = false;
+            return;
+        }
+        var current_mode = sailingApp.getMode();
         Sys.println("Current Mode: " + current_mode);
         if (current_mode == MODE_TYPE_STANDARD){
             if (secLeft > 1) {
@@ -128,6 +143,13 @@ class CountDown {
             } else {
                 finishCountdown();
             }
+        } else {
+            // Unknown countdown signal mode: keep timer progressing safely.
+            if (secLeft > 1) {
+                updateTimer();
+            } else {
+                finishCountdown();
+            }
         }
 
         WatchUi.requestUpdate();
@@ -158,19 +180,56 @@ class CountDown {
         Ui.requestUpdate();
     }
 
-    function endTimer() {
-        myTimer.stop();
+    function stopMainTimer() {
+        if (myTimer != null) {
+            myTimer.stop();
+            myTimer = null;
+        }
+    }
+
+    function stopFinalRingTimer() {
+        if (timerEnd != null) {
+            timerEnd.stop();
+            timerEnd = null;
+        }
+        finalRingTime = 5000;
+        timerComplete = false;
+    }
+
+    //! Cancel an active countdown without starting a race
+    function cancelTimer() {
+        stopMainTimer();
+        stopFinalRingTimer();
         timerRunning = false;
         Ui.requestUpdate();
     }
 
+    //! Forget race-start elapsed time (used when entering Cruise)
+    function clearRaceStart() {
+        raceStartTime = null;
+        Ui.requestUpdate();
+    }
+
+    //! Legacy alias used when toggling Start during a countdown
+    function endTimer() {
+        cancelTimer();
+    }
+
+    //! Stop all timers before the app is discarded
+    function shutdown() {
+        stopMainTimer();
+        stopFinalRingTimer();
+        timerRunning = false;
+    }
+
     function ring(buzz_type, times, tone) {
-        if (app.get().getAlarms() == false) {
+        var sailingApp = app.get();
+        if (sailingApp == null || sailingApp.getAlarms() == false) {
             return;
         }
         Sys.println("ring: " + times);
         var hasVibrate = (Attention has :vibrate);
-        var hasTone = (Attention has :ToneProfile);
+        var hasTone = (Attention has :ToneProfile) && (Attention has :playTone);
         if (buzz_type == BUZZ_SHORT) {
             if (times > 5){
                 Sys.println("ring: called with too many iterations (max 4)");
@@ -209,16 +268,17 @@ class CountDown {
     }
 
     function finalRing() as Void {
-        if (app.get().getAlarms() == false) {
+        var sailingApp = app.get();
+        if (sailingApp == null || sailingApp.getAlarms() == false) {
+            stopFinalRingTimer();
+            Ui.requestUpdate();
             return;
         }
         if (finalRingTime > 0) {
             finalRingTime -= 500;
             ring(BUZZ_LONG, 1, true);
         } else {
-            finalRingTime = 5000;
-            timerComplete = false;
-            timerEnd.stop();
+            stopFinalRingTimer();
         }
         Ui.requestUpdate();
     }

--- a/source/ModeMenuDelegate.mc
+++ b/source/ModeMenuDelegate.mc
@@ -5,13 +5,12 @@ using Toybox.System as Sys;
 class ModeMenuDelegate extends Ui.MenuInputDelegate {
 
     function initialize() {
-        // Call the setMode function with the desired enum value
         MenuInputDelegate.initialize();
     }
 
     function onMenuItem(item) {
         Sys.println("onMenuItem: " + item);
-        if (item == :mode_standard) {'
+        if (item == :mode_standard) {
             Sys.println("selected standard mode");
             App.getApp().setMode(MODE_TYPE_STANDARD);
         } else if (item == :mode_dynamic) {

--- a/source/SailingApp.mc
+++ b/source/SailingApp.mc
@@ -14,6 +14,11 @@ enum {
     MODE_TYPE_DYNAMIC
 }
 
+enum {
+    SAILING_MODE_RACE,
+    SAILING_MODE_CRUISE
+}
+
 class SailingApp extends App.AppBase {
 
     var session;
@@ -29,6 +34,9 @@ class SailingApp extends App.AppBase {
             return 5;
         }
         var time = Properties.getValue("time");
+        if (time < 0) {
+            return 5;
+        }
         return time;
     }
 
@@ -59,7 +67,7 @@ class SailingApp extends App.AppBase {
     function getMode() {
         if (! (App has :Properties)) {
             Sys.println("app : getMode no properties");
-            return true;
+            return MODE_TYPE_STANDARD;
         }
         return Properties.getValue("mode");
     }
@@ -71,6 +79,32 @@ class SailingApp extends App.AppBase {
         }
         Sys.println("app : setMode " + mode);
         Properties.setValue("mode", mode);
+    }
+
+    function getSailingMode() {
+        if (! (App has :Properties)) {
+            Sys.println("app : getSailingMode no properties");
+            return SAILING_MODE_RACE;
+        }
+        return Properties.getValue("sailingMode");
+    }
+
+    function setSailingMode(sailingMode) {
+        if (! (App has :Properties)) {
+            Sys.println("app : setSailingMode no properties");
+            return;
+        }
+        Sys.println("app : setSailingMode " + sailingMode);
+        Properties.setValue("sailingMode", sailingMode);
+        if (sailingMode == SAILING_MODE_CRUISE && countDown != null) {
+            countDown.cancelTimer();
+            countDown.clearRaceStart();
+        }
+        WatchUi.requestUpdate();
+    }
+
+    function isCruiseMode() {
+        return getSailingMode() == SAILING_MODE_CRUISE;
     }
 
     function initialize() {
@@ -90,10 +124,15 @@ class SailingApp extends App.AppBase {
     //! onStop() is called when your application is exiting
     function onStop(state) {
         Sys.println("app: onStop");
+        if (gpsSetupTimer != null) {
+            gpsSetupTimer.stop();
+            gpsSetupTimer = null;
+        }
+        if (countDown != null) {
+            countDown.shutdown();
+            countDown = null;
+        }
         sailingView = null;
-        gpsSetupTimer.stop();
-        gpsSetupTimer = null;
-        countDown = null;
 
         Position.enableLocationEvents(Position.LOCATION_DISABLE, method(:onPosition));
     }
@@ -112,25 +151,44 @@ class SailingApp extends App.AppBase {
 
     function startTimer() {
         Sys.println("app : start timer");
-        countDown.startTimer();
+        if (isCruiseMode()) {
+            Sys.println("app : start timer ignored in cruise mode");
+            return;
+        }
+        if (countDown != null) {
+            countDown.startTimer();
+        }
     }
 
     function startStopTimer() {
         Sys.println("app : startStop timer");
+        if (isCruiseMode()) {
+            Sys.println("app : startStop timer ignored in cruise mode");
+            return;
+        }
+        if (countDown == null) {
+            return;
+        }
         if (countDown.isTimerRunning() == false) {
             countDown.startTimer();
         } else {
-            countDown.endTimer();
+            countDown.cancelTimer();
         }
     }
 
     function fixTimeUp() {
         Sys.println("app : fixTimeUp");
+        if (isCruiseMode() || countDown == null) {
+            return;
+        }
         countDown.fixTimeUp();
     }
 
     function fixTimeDown() {
         Sys.println("app : fixTimeDown");
+        if (isCruiseMode() || countDown == null) {
+            return;
+        }
         countDown.fixTimeDown();
     }
 
@@ -142,8 +200,11 @@ class SailingApp extends App.AppBase {
     }
 
     function onPosition(info as Position.Info) as Void{
+        if (sailingView == null) {
+            return;
+        }
         sailingView.onPosition(info);
-        if (countDown.isTimerRunning() == false) {
+        if (countDown == null || countDown.isTimerRunning() == false) {
             WatchUi.requestUpdate();
         }
     }

--- a/source/SailingMenuDelegate.mc
+++ b/source/SailingMenuDelegate.mc
@@ -17,6 +17,9 @@ class SailingMenuDelegate extends Ui.MenuInputDelegate {
         } else if (item == :set_alarms) {
             Sys.println("set alarms pressed");
             App.getApp().setAlarms(! App.getApp().getAlarms());
+        } else if (item == :set_sailing_mode) {
+            Sys.println("set sailing mode pressed");
+            Ui.pushView(new Rez.Menus.SailingModeMenu(), new SailingModeMenuDelegate(), Ui.SLIDE_LEFT);
         } else if (item == :set_mode) {
             Sys.println("set mode pressed");
             Ui.pushView(new Rez.Menus.ModeMenu(), new ModeMenuDelegate(), Ui.SLIDE_LEFT);

--- a/source/SailingModeMenuDelegate.mc
+++ b/source/SailingModeMenuDelegate.mc
@@ -1,0 +1,19 @@
+using Toybox.WatchUi as Ui;
+using Toybox.Application as App;
+using Toybox.System as Sys;
+
+class SailingModeMenuDelegate extends Ui.MenuInputDelegate {
+
+    function initialize() {
+        MenuInputDelegate.initialize();
+    }
+
+    function onMenuItem(item) {
+        Sys.println("sailing mode item selected: " + item);
+        if (item == :sailing_mode_cruise) {
+            App.getApp().setSailingMode(SAILING_MODE_CRUISE);
+        } else if (item == :sailing_mode_race) {
+            App.getApp().setSailingMode(SAILING_MODE_RACE);
+        }
+    }
+}

--- a/source/SailingView.mc
+++ b/source/SailingView.mc
@@ -58,7 +58,12 @@ class SailingView extends Ui.View {
     }
 
     function updateTimer() {
-        var secLeft = countDown.get().secondsLeft();
+        var countdownObj = countDown.get();
+        if (countdownObj == null) {
+            countDownStr = "";
+            return;
+        }
+        var secLeft = countdownObj.secondsLeft();
 
         sec = secLeft % 60;
         min = secLeft / 60;
@@ -82,12 +87,16 @@ class SailingView extends Ui.View {
     function onUpdate(dc) {
         Sys.println("view : onUpdate");
         var now = Time.now();
+        var countdownObj = null;
+        if (countDown != null) {
+            countdownObj = countDown.get();
+        }
 
         dc.setColor( Gfx.COLOR_TRANSPARENT, Gfx.COLOR_BLACK );
         dc.clear();
         dc.setColor( Gfx.COLOR_GREEN, Gfx.COLOR_TRANSPARENT );
 
-        if (countDown.get().isTimerRunning()) {
+        if (countdownObj != null && countdownObj.isTimerRunning()) {
             updateTimer();
             var polygon = buildProgress();
 
@@ -103,7 +112,7 @@ class SailingView extends Ui.View {
             dc.setColor( Gfx.COLOR_WHITE, Gfx.COLOR_TRANSPARENT );
             dc.drawText( (screenWidth / 2), (screenHeight / 2) - (Gfx.getFontHeight(Gfx.FONT_NUMBER_THAI_HOT) / 2), Gfx.FONT_NUMBER_THAI_HOT, countDownStr, Gfx.TEXT_JUSTIFY_CENTER );
 
-        } else if (countDown.get().isTimerComplete()) {
+        } else if (countdownObj != null && countdownObj.isTimerComplete()) {
             dc.setColor( Gfx.COLOR_WHITE, Gfx.COLOR_BLACK );
             dc.drawText( (screenWidth / 2), (screenHeight / 2) - (Gfx.getFontHeight(Gfx.FONT_LARGE) / 2), Gfx.FONT_LARGE, "START", Gfx.TEXT_JUSTIFY_CENTER );
 
@@ -137,6 +146,10 @@ class SailingView extends Ui.View {
                         dc.drawText((screenWidth / 2), (screenHeight / 2), Gfx.FONT_NUMBER_THAI_HOT, speedStr, Gfx.TEXT_JUSTIFY_CENTER);
                         dc.drawText((3 * (screenWidth / 4)) + unitsOffset, (screenHeight / 2), Gfx.FONT_MEDIUM, SPEED_UNIT, Gfx.TEXT_JUSTIFY_LEFT);
                         dc.drawText((subscreen.x + (subscreen.width / 2) + 4), (subscreen.y + (subscreen.height/4)), Gfx.FONT_MEDIUM, headingOnlyStr, Gfx.TEXT_JUSTIFY_CENTER);
+                    } else {
+                        dc.drawText((screenWidth / 2), yOffset, Gfx.FONT_TINY , nowString, Gfx.TEXT_JUSTIFY_CENTER);
+                        dc.drawText((screenWidth / 2), yOffset + Gfx.getFontAscent(Gfx.FONT_MEDIUM), Gfx.FONT_NUMBER_THAI_HOT, speedStr, Gfx.TEXT_JUSTIFY_CENTER);
+                        dc.drawText((screenWidth / 2), yOffset + Gfx.getFontAscent(Gfx.FONT_NUMBER_THAI_HOT) + Gfx.getFontAscent(Gfx.FONT_MEDIUM) + 40, Gfx.FONT_MEDIUM, headingStr, Gfx.TEXT_JUSTIFY_CENTER);
                     }
                 } else {
                     dc.drawText((screenWidth / 2), yOffset, Gfx.FONT_TINY , nowString, Gfx.TEXT_JUSTIFY_CENTER);
@@ -144,7 +157,10 @@ class SailingView extends Ui.View {
                     dc.drawText((screenWidth / 2), yOffset + Gfx.getFontAscent(Gfx.FONT_NUMBER_THAI_HOT) + Gfx.getFontAscent(Gfx.FONT_MEDIUM) + 40, Gfx.FONT_MEDIUM, headingStr, Gfx.TEXT_JUSTIFY_CENTER);
                 }
 
-                var raceStartTime = countDown.get().startTime();
+                var raceStartTime = null;
+                if (countdownObj != null) {
+                    raceStartTime = countdownObj.startTime();
+                }
 
                 if(raceStartTime != null){
                     //print running timer
@@ -178,7 +194,11 @@ class SailingView extends Ui.View {
 
         var polygon = [];
 
-        if (countDown.get().isTimerComplete()) {
+        var countdownObj = null;
+        if (countDown != null) {
+            countdownObj = countDown.get();
+        }
+        if (countdownObj != null && countdownObj.isTimerComplete()) {
             polygon = [
                     [0, 0],
                     [border_x, 0],
@@ -274,18 +294,37 @@ class SailingView extends Ui.View {
     }
 
     function onPosition(info) {
-        var heading = info.heading;
-        headingStr = headingToStr(heading);
-        var headingDeg = ((180 * heading ) /  Math.PI);
-        if (headingDeg < 0) {
-            headingDeg += 360;
+        if (info == null) {
+            return;
         }
-        headingOnlyStr = headingDeg.format("%d") + "°";
-        headingStr += " - " + headingDeg.format("%d");
-        accuracyStr = info.accuracy.format("%d");
-        speedFloat = info.speed * 1.943844492;
-        speedStr = (info.speed * 1.943844492).format("%0.1f");
-        Sys.println("speed: " +speedStr+ " (" +info.speed+ ") heading: " +headingStr+ " (" +heading+ ")  accuracy: " +accuracyStr);
+
+        if (info.accuracy != null) {
+            accuracyStr = info.accuracy.format("%d");
+        }
+
+        if (info.heading != null) {
+            var heading = info.heading;
+            headingStr = headingToStr(heading);
+            var headingDeg = ((180 * heading ) /  Math.PI);
+            if (headingDeg < 0) {
+                headingDeg += 360;
+            }
+            headingOnlyStr = headingDeg.format("%d") + "°";
+            headingStr += " - " + headingDeg.format("%d");
+        } else {
+            headingStr = "-";
+            headingOnlyStr = "-";
+        }
+
+        if (info.speed != null) {
+            speedFloat = info.speed * 1.943844492;
+            speedStr = speedFloat.format("%0.1f");
+        } else {
+            speedFloat = 0.0;
+            speedStr = "-";
+        }
+
+        Sys.println("speed: " +speedStr+ " heading: " +headingStr+ " accuracy: " +accuracyStr);
     }
 
     function headingToStr(heading){


### PR DESCRIPTION
Lets non-racing sailors keep speed, bearing, and GPS tracking without Start triggering the countdown, and hardens timer shutdown against crash paths.