### PR TITLE
Integrate PR #20: fix timer completion when alarms are off

### DIFF
--- a/source/CountDown.mc
+++ b/source/CountDown.mc
@@ -66,7 +66,6 @@ class CountDown {
         raceStartTime = Time.now();
         endTimer();
         timerComplete = true;
-        finalRing();
         timerEnd = new Timer.Timer();
         timerEnd.start(method(:finalRing), 500, true );
     }
@@ -210,6 +209,7 @@ class CountDown {
 
     function finalRing() as Void {
         if (app.get().getAlarms() == false) {
+            timerComplete = false;
             return;
         }
         if (finalRingTime > 0) {


### PR DESCRIPTION
## Summary
- Integrates [#20](https://github.com/dmrrlc/connectiq-sailing/pull/20) into current `master` after the cruise-mode rewrite of `CountDown.mc` made it unmergeable.
- Keeps cruise-mode null-safe shutdown via `stopFinalRingTimer()` (clears `timerComplete` and stops the leaking final-ring timer).
- Adopts PR #20’s removal of the synchronous `finalRing()` call in `finishCountdown()`.

## Test plan
- [ ] Race countdown with alarms ON: START flash + final buzz, then telemetry
- [ ] Race countdown with alarms OFF: START flash clears; screen does not stick on START
- [ ] Build for fenix7


Made with [Cursor](https://cursor.com)